### PR TITLE
Add handling for non-public taxonomies

### DIFF
--- a/includes/class-novelist-book.php
+++ b/includes/class-novelist-book.php
@@ -512,7 +512,7 @@ class Novelist_Book {
 	public function get_genre() {
 
 		if ( ! isset( $this->genre ) ) {
-			$this->genre = get_the_term_list( $this->ID, 'novelist-genre', '', ', ', '' );
+			$this->genre = novelist_get_taxonomy_term_list($this->ID, 'novelist-genre');
 		}
 
 		return apply_filters( 'novelist/book/get/genre', $this->genre, $this->ID );


### PR DESCRIPTION
Allows a code snippet like this:

```php
add_filter('novelist/taxonomy/series-args', 'agNovelistDisableArchives');
add_filter('novelist/taxonomy/genre-args', 'agNovelistDisableArchives');

function agNovelistDisableArchives($args) {
	$args['public'] = false;
	
	return $args;
}
```

to disable the links to the taxonomy term archives.